### PR TITLE
tests: fix path to words file on Gentoo/CoreOS

### DIFF
--- a/tests/util/grub-fs-tester.in
+++ b/tests/util/grub-fs-tester.in
@@ -230,8 +230,10 @@ for ((LOGSECSIZE=MINLOGSECSIZE;LOGSECSIZE<=MAXLOGSECSIZE;LOGSECSIZE=LOGSECSIZE +
 	    CFILESN=1
 	    if test -f /usr/share/dict/american-english; then
 		CFILESSRC[0]="/usr/share/dict/american-english"
-	    else
+	    elif test -f /usr/share/dict/linux.words; then
 		CFILESSRC[0]="/usr/share/dict/linux.words"
+	    else
+		CFILESSRC[0]="/usr/share/dict/words"
 	    fi
 	    case x"$fs" in
 		    # FS LIMITATION: 8.3 names


### PR DESCRIPTION
By default there isn't a linux.words file, but there is words.
