### PR TITLE
Pass through data from the kernel binary to the kernel

### DIFF
--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -27,6 +27,8 @@
 #include <grub/lib/cmdline.h>
 #include <grub/efi/efi.h>
 
+#include "../verity-hash.h"
+
 GRUB_MOD_LICENSE ("GPLv3+");
 
 static grub_dl_t my_mod;
@@ -288,6 +290,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
                               linux_cmdline + sizeof (LINUX_IMAGE) - 1,
 			      lh.cmdline_size - (sizeof (LINUX_IMAGE) - 1));
 
+  grub_pass_verity_hash(&lh, linux_cmdline);
   lh.cmd_line_ptr = (grub_uint32_t)(grub_uint64_t)linux_cmdline;
 
   handover_offset = lh.handover_offset;

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -36,6 +36,7 @@
 #include <grub/lib/cmdline.h>
 #include <grub/linux.h>
 
+#include "verity-hash.h"
 GRUB_MOD_LICENSE ("GPLv3+");
 
 #ifdef GRUB_MACHINE_PCBIOS
@@ -1016,6 +1017,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 			      maximal_cmdline_size
 			      - (sizeof (LINUX_IMAGE) - 1));
 
+  grub_pass_verity_hash(&lh, linux_cmdline);
   len = prot_file_size;
   if (grub_file_read (file, prot_mode_mem, len) != len && !grub_errno)
     grub_error (GRUB_ERR_BAD_OS, N_("premature end of file %s"),

--- a/grub-core/loader/i386/verity-hash.h
+++ b/grub-core/loader/i386/verity-hash.h
@@ -1,0 +1,25 @@
+#define VERITY_ARG " verity.usrhash="
+#define VERITY_HASH_OFFSET 0x40
+#define VERITY_HASH_LENGTH 64
+
+static inline void grub_pass_verity_hash(struct linux_kernel_header *lh,
+					 char *cmdline)
+{
+  char *buf = (char *)lh;
+  grub_size_t cmdline_len;
+  int i;
+
+  for (i=VERITY_HASH_OFFSET; i<VERITY_HASH_OFFSET + VERITY_HASH_LENGTH; i++)
+    {
+      if (buf[i] < '0' || buf[i] > '9') // Not a number
+	if (buf[i] < 'a' || buf[i] > 'f') // Not a hex letter
+	  return;
+    }
+
+  grub_memcpy (cmdline + grub_strlen(cmdline), VERITY_ARG,
+	       sizeof (VERITY_ARG));
+  cmdline_len = grub_strlen(cmdline);
+  grub_memcpy (cmdline + cmdline_len, buf + VERITY_HASH_OFFSET,
+	       VERITY_HASH_LENGTH);
+  cmdline[cmdline_len + VERITY_HASH_LENGTH] = '\0';
+}


### PR DESCRIPTION
The easiest way to pass the Verity root key from a trusted object to the OS is to store it in a signed object (ie, the kernel) and pass it via a trusted interface (in this case, the standard EFI variable mechanism). The running OS can then retrieve it and verify the filesystem. For now we'll just reuse the space the kernel uses to store an error message printed when you attempt to boot the kernel directly from floppy since it seems unlikely we're ever going to care about that case.