### PR TITLE
TPM fixes

### DIFF
--- a/grub-core/boot/i386/pc/boot.S
+++ b/grub-core/boot/i386/pc/boot.S
@@ -476,9 +476,9 @@ LOCAL(copy_buffer):
 	movl	$0x8, %edx		/* PCR 8 */
 	int	$0x1A
 
+boot:
 	popa
 #endif
-boot:
 	/* boot kernel */
 	jmp	*(LOCAL(kernel_address))
 

--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -724,7 +724,7 @@ grub_dl_load_file (const char *filename)
      opens of the same device.  */
   grub_file_close (file);
 
-  grub_tpm_measure(core, size, GRUB_TPM_PCR, filename);
+  grub_tpm_measure(core, size, GRUB_BINARY_PCR, "grub_module", filename);
 
   mod = grub_dl_load_core (core, size);
   grub_free (core);

--- a/grub-core/kern/tpm.c
+++ b/grub-core/kern/tpm.c
@@ -7,7 +7,13 @@
 
 grub_err_t
 grub_tpm_measure (unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
-		  const char *description)
+		  const char *kind, const char *description)
 {
-  return grub_tpm_log_event(buf, size, pcr, description);
+  grub_err_t ret;
+  char *desc = grub_xasprintf("%s %s", kind, description);
+  if (!desc)
+    return GRUB_ERR_OUT_OF_MEMORY;
+  ret = grub_tpm_log_event(buf, size, pcr, description);
+  grub_free(desc);
+  return ret;
 }

--- a/grub-core/lib/cmdline.c
+++ b/grub-core/lib/cmdline.c
@@ -105,8 +105,8 @@ int grub_create_loader_cmdline (int argc, char *argv[], char *buf,
 
   *buf = 0;
 
-  grub_tpm_measure ((void *)orig, grub_strlen (orig), GRUB_CMDLINE_PCR,
-		    "Kernel Commandline");
+  grub_tpm_measure ((void *)orig, grub_strlen (orig), GRUB_ASCII_PCR,
+		    "grub_kernel_cmdline", orig);
 
   return i;
 }

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -169,7 +169,7 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
                         argv[i]);
           goto fail;
         }
-      grub_tpm_measure (ptr, cursize, GRUB_INITRD_PCR, "UEFI Linux initrd");
+      grub_tpm_measure (ptr, cursize, GRUB_BINARY_PCR, "grub_linuxefi", "Initrd");
       ptr += cursize;
       grub_memset (ptr, 0, ALIGN_UP_OVERHEAD (cursize, 4));
       ptr += ALIGN_UP_OVERHEAD (cursize, 4);
@@ -225,7 +225,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       goto fail;
     }
 
-  grub_tpm_measure (kernel, filelen, GRUB_KERNEL_PCR, "UEFI Linux kernel");
+  grub_tpm_measure (kernel, filelen, GRUB_BINARY_PCR, "grub_linuxefi", "Kernel");
 
   if (! grub_linuxefi_secure_validate (kernel, filelen))
     {

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -718,7 +718,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       goto fail;
     }
 
-  grub_tpm_measure (kernel, len, GRUB_KERNEL_PCR, "Linux Kernel");
+  grub_tpm_measure (kernel, len, GRUB_BINARY_PCR, "grub_linux", "Kernel");
 
   grub_memcpy (&lh, kernel, sizeof (lh));
 

--- a/grub-core/loader/i386/multiboot_mbi.c
+++ b/grub-core/loader/i386/multiboot_mbi.c
@@ -165,7 +165,7 @@ grub_multiboot_load (grub_file_t file, const char *filename)
       return grub_errno;
     }
 
-  grub_tpm_measure((unsigned char*)buffer, len, GRUB_KERNEL_PCR, filename);
+  grub_tpm_measure((unsigned char*)buffer, len, GRUB_BINARY_PCR, "grub_multiboot", filename);
 
   header = find_header (buffer, len);
 

--- a/grub-core/loader/i386/pc/linux.c
+++ b/grub-core/loader/i386/pc/linux.c
@@ -161,7 +161,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
       goto fail;
     }
 
-  grub_tpm_measure (kernel, len, GRUB_KERNEL_PCR, "BIOS Linux Kernel");
+  grub_tpm_measure (kernel, len, GRUB_BINARY_PCR, "grub_linux16", "Kernel");
 
   grub_memcpy (&lh, kernel, sizeof (lh));
   kernel_offset = sizeof (lh);

--- a/grub-core/loader/linux.c
+++ b/grub-core/loader/linux.c
@@ -289,7 +289,7 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
 	  grub_initrd_close (initrd_ctx);
 	  return grub_errno;
 	}
-      grub_tpm_measure (ptr, cursize, GRUB_INITRD_PCR, "Linux Initrd");
+      grub_tpm_measure (ptr, cursize, GRUB_BINARY_PCR, "grub_initrd", "Initrd");
       ptr += cursize;
     }
   if (newc)

--- a/grub-core/loader/multiboot.c
+++ b/grub-core/loader/multiboot.c
@@ -385,7 +385,7 @@ grub_cmd_module (grub_command_t cmd __attribute__ ((unused)),
     }
 
   grub_file_close (file);
-  grub_tpm_measure (module, size, GRUB_KERNEL_PCR, argv[0]);
+  grub_tpm_measure (module, size, GRUB_BINARY_PCR, "grub_multiboot", argv[0]);
   return GRUB_ERR_NONE;
 }
 

--- a/grub-core/loader/multiboot_mbi2.c
+++ b/grub-core/loader/multiboot_mbi2.c
@@ -127,7 +127,7 @@ grub_multiboot_load (grub_file_t file, const char *filename)
 
   COMPILE_TIME_ASSERT (MULTIBOOT_HEADER_ALIGN % 4 == 0);
 
-  grub_tpm_measure ((unsigned char *)buffer, len, GRUB_KERNEL_PCR, filename);
+  grub_tpm_measure ((unsigned char *)buffer, len, GRUB_BINARY_PCR, "grub_multiboot", filename);
 
   header = find_header (buffer, len);
 

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -961,8 +961,8 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
 				   argv.args[i]);
   }
   cmdstring[cmdlen-1]= '\0';
-  grub_tpm_measure ((unsigned char *)cmdstring, cmdlen, GRUB_COMMAND_PCR,
-		    cmdstring);
+  grub_tpm_measure ((unsigned char *)cmdstring, cmdlen, GRUB_ASCII_PCR,
+		    "grub_cmd", cmdstring);
   grub_free(cmdstring);
   invert = 0;
   argc = argv.argc - 1;

--- a/include/grub/tpm.h
+++ b/include/grub/tpm.h
@@ -26,11 +26,8 @@
 #define TPM_AUTHFAIL (TPM_BASE + 0x1)
 #define TPM_BADINDEX (TPM_BASE + 0x2)
 
-#define GRUB_TPM_PCR 9
-#define GRUB_KERNEL_PCR 10
-#define GRUB_INITRD_PCR 11
-#define GRUB_CMDLINE_PCR 12
-#define GRUB_COMMAND_PCR 13
+#define GRUB_ASCII_PCR 8
+#define GRUB_BINARY_PCR 9
 
 #define TPM_TAG_RQU_COMMAND 0x00C1
 #define TPM_ORD_Extend 0x14
@@ -70,7 +67,7 @@ typedef struct {
 } GRUB_PACKED ExtendOutgoing;
 
 grub_err_t EXPORT_FUNC(grub_tpm_measure) (unsigned char *buf, grub_size_t size,
-					  grub_uint8_t pcr,
+					  grub_uint8_t pcr, const char *kind,
 					  const char *description);
 #if defined (GRUB_MACHINE_EFI) || defined (GRUB_MACHINE_PCBIOS)
 grub_err_t grub_tpm_execute(PassThroughToTPM_InputParamBlock *inbuf,


### PR DESCRIPTION
Fix boot on BIOS-based systems that have TPM firmware but no TPM, and change the way we measure into PCRs to be more compatible with how the rest of the community would like this to work.