### PR TITLE
Fix event log prefix

### DIFF
--- a/grub-core/kern/tpm.c
+++ b/grub-core/kern/tpm.c
@@ -13,7 +13,7 @@ grub_tpm_measure (unsigned char *buf, grub_size_t size, grub_uint8_t pcr,
   char *desc = grub_xasprintf("%s %s", kind, description);
   if (!desc)
     return GRUB_ERR_OUT_OF_MEMORY;
-  ret = grub_tpm_log_event(buf, size, pcr, description);
+  ret = grub_tpm_log_event(buf, size, pcr, desc);
   grub_free(desc);
   return ret;
 }


### PR DESCRIPTION
We're not passing the prefixed version of the description to the event log.
Fix that.