### PR TITLE
net: add client arch and fix user class/terminator

### DIFF
--- a/grub-core/net/bootp.c
+++ b/grub-core/net/bootp.c
@@ -25,11 +25,21 @@
 #include <grub/net/udp.h>
 #include <grub/datetime.h>
 
+#if !defined(GRUB_MACHINE_EFI) && (defined(__i386__) || defined(__x86_64__))
+#define GRUB_NET_BOOTP_ARCH 0x0000
+#elif defined(GRUB_MACHINE_EFI) && defined(__x86_64__)
+#define GRUB_NET_BOOTP_ARCH 0x0007
+#elif defined(GRUB_MACHINE_EFI) && defined(__aarch64__)
+#define GRUB_NET_BOOTP_ARCH 0x000B
+#else
+#error "unknown bootp architecture"
+#endif
+
 static grub_uint8_t dhcp_option_header[] = {GRUB_NET_BOOTP_RFC1048_MAGIC_0,
 					    GRUB_NET_BOOTP_RFC1048_MAGIC_1,
 					    GRUB_NET_BOOTP_RFC1048_MAGIC_2,
 					    GRUB_NET_BOOTP_RFC1048_MAGIC_3};
-static grub_uint8_t grub_userclass[] = {0x4D, 0x05, 'G', 'R', 'U', 'B', '2'};
+static grub_uint8_t grub_userclass[] = {0x4D, 0x06, 0x05, 'G', 'R', 'U', 'B', '2'};
 static grub_uint8_t grub_dhcpdiscover[] = {0x35, 0x01, 0x01};
 static grub_uint8_t grub_dhcptime[] = {0x33, 0x04, 0x00, 0x00, 0x0e, 0x10};
 
@@ -545,6 +555,16 @@ grub_cmd_bootp (struct grub_command *cmd __attribute__ ((unused)),
 	  grub_memcpy (offset, grub_userclass, sizeof(grub_userclass));
 	  offset += sizeof(grub_userclass);
 	  grub_memcpy (offset, grub_dhcptime, sizeof(grub_dhcptime));
+
+	  /* insert Client System Architecture (option 93) */
+	  offset += sizeof(grub_dhcptime);
+	  offset[0] = 93;
+	  offset[1] = 2;
+	  offset[2] = (GRUB_NET_BOOTP_ARCH >> 8);
+	  offset[3] = (GRUB_NET_BOOTP_ARCH & 0xFF);
+
+	  /* option terminator */
+	  offset[4] = 255;
 
 	  grub_netbuff_push (nb, sizeof (*udph));
 


### PR DESCRIPTION
send client arch in bootp requests, for now BIOS and x64/aarch64 EFI is
supported.

fix a bug introduced in 4d5d7be005bb5c15c07472461b528dea65a58cc6 where
user class was encoded improperly, although this didn't seem to have any
detrimental effects.

properly insert an option terminator.