### PR TITLE
Make TPM errors less fatal

### DIFF
--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -725,6 +725,7 @@ grub_dl_load_file (const char *filename)
   grub_file_close (file);
 
   grub_tpm_measure(core, size, GRUB_BINARY_PCR, "grub_module", filename);
+  grub_print_error();
 
   mod = grub_dl_load_core (core, size);
   grub_free (core);

--- a/grub-core/lib/cmdline.c
+++ b/grub-core/lib/cmdline.c
@@ -107,6 +107,7 @@ int grub_create_loader_cmdline (int argc, char *argv[], char *buf,
 
   grub_tpm_measure ((void *)orig, grub_strlen (orig), GRUB_ASCII_PCR,
 		    "grub_kernel_cmdline", orig);
+  grub_print_error();
 
   return i;
 }

--- a/grub-core/loader/i386/efi/linux.c
+++ b/grub-core/loader/i386/efi/linux.c
@@ -170,6 +170,7 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
           goto fail;
         }
       grub_tpm_measure (ptr, cursize, GRUB_BINARY_PCR, "grub_linuxefi", "Initrd");
+      grub_print_error();
       ptr += cursize;
       grub_memset (ptr, 0, ALIGN_UP_OVERHEAD (cursize, 4));
       ptr += ALIGN_UP_OVERHEAD (cursize, 4);
@@ -226,6 +227,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
 
   grub_tpm_measure (kernel, filelen, GRUB_BINARY_PCR, "grub_linuxefi", "Kernel");
+  grub_print_error();
 
   if (! grub_linuxefi_secure_validate (kernel, filelen))
     {

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -719,6 +719,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
 
   grub_tpm_measure (kernel, len, GRUB_BINARY_PCR, "grub_linux", "Kernel");
+  grub_print_error();
 
   grub_memcpy (&lh, kernel, sizeof (lh));
 

--- a/grub-core/loader/i386/multiboot_mbi.c
+++ b/grub-core/loader/i386/multiboot_mbi.c
@@ -166,6 +166,7 @@ grub_multiboot_load (grub_file_t file, const char *filename)
     }
 
   grub_tpm_measure((unsigned char*)buffer, len, GRUB_BINARY_PCR, "grub_multiboot", filename);
+  grub_print_error();
 
   header = find_header (buffer, len);
 

--- a/grub-core/loader/i386/pc/linux.c
+++ b/grub-core/loader/i386/pc/linux.c
@@ -162,6 +162,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
 
   grub_tpm_measure (kernel, len, GRUB_BINARY_PCR, "grub_linux16", "Kernel");
+  grub_print_error();
 
   grub_memcpy (&lh, kernel, sizeof (lh));
   kernel_offset = sizeof (lh);

--- a/grub-core/loader/linux.c
+++ b/grub-core/loader/linux.c
@@ -290,6 +290,8 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
 	  return grub_errno;
 	}
       grub_tpm_measure (ptr, cursize, GRUB_BINARY_PCR, "grub_initrd", "Initrd");
+      grub_print_error();
+
       ptr += cursize;
     }
   if (newc)

--- a/grub-core/loader/multiboot.c
+++ b/grub-core/loader/multiboot.c
@@ -386,6 +386,7 @@ grub_cmd_module (grub_command_t cmd __attribute__ ((unused)),
 
   grub_file_close (file);
   grub_tpm_measure (module, size, GRUB_BINARY_PCR, "grub_multiboot", argv[0]);
+  grub_print_error();
   return GRUB_ERR_NONE;
 }
 

--- a/grub-core/loader/multiboot_mbi2.c
+++ b/grub-core/loader/multiboot_mbi2.c
@@ -128,6 +128,7 @@ grub_multiboot_load (grub_file_t file, const char *filename)
   COMPILE_TIME_ASSERT (MULTIBOOT_HEADER_ALIGN % 4 == 0);
 
   grub_tpm_measure ((unsigned char *)buffer, len, GRUB_BINARY_PCR, "grub_multiboot", filename);
+  grub_print_error();
 
   header = find_header (buffer, len);
 

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -963,6 +963,7 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
   cmdstring[cmdlen-1]= '\0';
   grub_tpm_measure ((unsigned char *)cmdstring, cmdlen, GRUB_ASCII_PCR,
 		    "grub_cmd", cmdstring);
+  grub_print_error();
   grub_free(cmdstring);
   invert = 0;
   argc = argv.argc - 1;


### PR DESCRIPTION
Handle TPM errors, and stop trying to use the TPM once we hit one.