### PR TITLE
loader/i386: fix out of bound memory copy on non-UEFI linux

### DIFF
--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -826,7 +826,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
 
   len = sizeof (linux_params) - sizeof (lh);
 
-  grub_memcpy (&linux_params + sizeof (lh), kernel + kernel_offset, len);
+  grub_memcpy ((char *) &linux_params + sizeof (lh), kernel + kernel_offset, len);
   kernel_offset += len;
 
   linux_params.type_of_loader = GRUB_LINUX_BOOT_LOADER_TYPE;


### PR DESCRIPTION
Ref: https://bugzilla.opensuse.org/show_bug.cgi?id=1029187
Ref: https://build.opensuse.org/package/rdiff/openSUSE:Factory/grub2?linkrev=base&rev=159
Ref: https://github.com/coreos/bugs/issues/2284