### PR TITLE
Don't measure trailing NUL of grub_cmd

### DIFF
--- a/grub-core/kern/dl.c
+++ b/grub-core/kern/dl.c
@@ -731,6 +731,7 @@ grub_dl_load_file (const char *filename)
   grub_file_close (file);
 
   grub_tpm_measure(core, size, GRUB_BINARY_PCR, "grub_module", filename);
+  grub_dprintf("tpm", "grub_module %s\n", filename);
   grub_print_error();
 
   mod = grub_dl_load_core (core, size);

--- a/grub-core/lib/cmdline.c
+++ b/grub-core/lib/cmdline.c
@@ -107,6 +107,7 @@ int grub_create_loader_cmdline (int argc, char *argv[], char *buf,
 
   grub_tpm_measure ((void *)orig, grub_strlen (orig), GRUB_ASCII_PCR,
 		    "grub_kernel_cmdline", orig);
+  grub_dprintf("tpm", "grub_kernel_cmdline %s\n", orig);
   grub_print_error();
 
   return i;

--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -720,6 +720,7 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
     }
 
   grub_tpm_measure (kernel, len, GRUB_BINARY_PCR, "grub_linux", "Kernel");
+  grub_dprintf("tpm", "grub_linux %s\n", argv[0]);
   grub_print_error();
 
   grub_memcpy (&lh, kernel, sizeof (lh));

--- a/grub-core/loader/linux.c
+++ b/grub-core/loader/linux.c
@@ -290,6 +290,7 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
 	  return grub_errno;
 	}
       grub_tpm_measure (ptr, cursize, GRUB_BINARY_PCR, "grub_initrd", "Initrd");
+	  grub_dprintf("tpm", "grub_initrd %s\n", argv[i]);
       grub_print_error();
 
       ptr += cursize;

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -962,6 +962,7 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
   {
       grub_tpm_measure ((unsigned char *)cmdstring, cmdlen-1, GRUB_ASCII_PCR,
 			    "grub_cmd", cmdstring);
+      grub_dprintf("tpm", "grub_cmd %s\n", cmdstring);
   }
   grub_print_error();
   grub_free(cmdstring);

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -957,7 +957,7 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
 				   argv.args[i]);
   }
   cmdstring[cmdlen-1]= '\0';
-  grub_tpm_measure ((unsigned char *)cmdstring, cmdlen, GRUB_ASCII_PCR,
+  grub_tpm_measure ((unsigned char *)cmdstring, cmdlen-1, GRUB_ASCII_PCR,
 		    "grub_cmd", cmdstring);
   grub_print_error();
   grub_free(cmdstring);

--- a/grub-core/script/execute.c
+++ b/grub-core/script/execute.c
@@ -957,8 +957,12 @@ grub_script_execute_cmdline (struct grub_script_cmd *cmd)
 				   argv.args[i]);
   }
   cmdstring[cmdlen-1]= '\0';
-  grub_tpm_measure ((unsigned char *)cmdstring, cmdlen-1, GRUB_ASCII_PCR,
-		    "grub_cmd", cmdstring);
+  if ( grub_strncmp( cmdstring, "menuentry ", grub_strlen( "menuentry " ) ) != 0 &&
+       grub_strncmp( cmdstring, "submenu ", grub_strlen( "submenu " ) ) != 0)
+  {
+      grub_tpm_measure ((unsigned char *)cmdstring, cmdlen-1, GRUB_ASCII_PCR,
+			    "grub_cmd", cmdstring);
+  }
   grub_print_error();
   grub_free(cmdstring);
   invert = 0;


### PR DESCRIPTION
It makes pre-calculation difficult without reading the source code.