### PR TITLE
x86-64: Treat R_X86_64_PLT32 as R_X86_64_PC32

### DIFF
--- a/grub-core/efiemu/i386/loadcore64.c
+++ b/grub-core/efiemu/i386/loadcore64.c
@@ -98,6 +98,7 @@ grub_arch_efiemu_relocate_symbols64 (grub_efiemu_segment_t segs,
 		    break;
 
 		  case R_X86_64_PC32:
+		  case R_X86_64_PLT32:
 		    err = grub_efiemu_write_value (addr,
 						   *addr32 + rel->r_addend
 						   + sym.off

--- a/grub-core/kern/x86_64/dl.c
+++ b/grub-core/kern/x86_64/dl.c
@@ -70,6 +70,7 @@ grub_arch_dl_relocate_symbols (grub_dl_t mod, void *ehdr,
 	  break;
 
 	case R_X86_64_PC32:
+	case R_X86_64_PLT32:
 	  {
 	    grub_int64_t value;
 	    value = ((grub_int32_t) *addr32) + rel->r_addend + sym->st_value -

--- a/util/grub-mkimagexx.c
+++ b/util/grub-mkimagexx.c
@@ -832,6 +832,7 @@ SUFFIX (relocate_addresses) (Elf_Ehdr *e, Elf_Shdr *sections,
 		  break;
 
 		case R_X86_64_PC32:
+		case R_X86_64_PLT32:
 		  {
 		    grub_uint32_t *t32 = (grub_uint32_t *) target;
 		    *t32 = grub_host_to_target64 (grub_target_to_host32 (*t32)

--- a/util/grub-module-verifier.c
+++ b/util/grub-module-verifier.c
@@ -19,6 +19,7 @@ struct grub_module_verifier_arch archs[] = {
       -1
     }, (int[]){
       R_X86_64_PC32,
+      R_X86_64_PLT32,
       -1
     }
   },


### PR DESCRIPTION
Starting from binutils commit bd7ab16b4537788ad53521c45469a1bdae84ad4a:

https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=bd7ab16b4537788ad53521c45469a1bdae84ad4a

x86-64 assembler generates R_X86_64_PLT32, instead of R_X86_64_PC32, for
32-bit PC-relative branches.  Grub2 should treat R_X86_64_PLT32 as
R_X86_64_PC32.

Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
(cherry picked from commit 842c390469e2c2e10b5aa36700324cd3bde25875)